### PR TITLE
Fix undefined ansible_ssh_user

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -15,7 +15,7 @@
     append: yes
   with_items: users
   when: >
-    not ( item.name == ansible_ssh_user and
+    not ( item.name == ansible_ssh_user|default(lookup('env', 'USER')) and
     item.state|default('present') == 'absent' )
 
 - name: Add admin users to admin group


### PR DESCRIPTION
When ansible_ssh_user is not configured, task "Create users" fails with
message "'ansible_ssh_user' is undefined". To avoid it, a simple
fallback to the `$USER` environment variable is made.
