### PR TITLE
Add bashrc commands file

### DIFF
--- a/tasks/add_bashrc_commands.yml
+++ b/tasks/add_bashrc_commands.yml
@@ -1,0 +1,9 @@
+---
+- name: Create bashrc commands
+  blockinfile:
+    path: /home/{{item.name}}/.bashrc
+    block: '{{ item.bashrc_commands }}'
+  with_items: "{{ users }}"
+  when: >
+    users_per_user_groups == true and
+    item.state|default('present') != 'absent'


### PR DESCRIPTION
Hello.

Example settings for this feature:

vars:
```
users:
- name: renan
  is_admin: yes
  bashrc_commands: |
    export PATH=$PATH:/example/bin
    visualizar_ajuda
```