### PR TITLE
Making this role compatible with Ansible 2.9

### DIFF
--- a/tasks/sudo.yml
+++ b/tasks/sudo.yml
@@ -1,9 +1,8 @@
 ---
 - name: Sudo installed
-  action: >
-    {{ ansible_pkg_mgr }}
-    name='sudo'
-    state='installed'
+  package:
+    name: sudo
+    state: present
 
 - name: Admin sudoers
   template:


### PR DESCRIPTION
apt module doesn't accept state=installed anymore.

Also starting to use package module instead of {{ ansible_pkg_mgr }} variable.